### PR TITLE
fix: corrects the spelling "Licence" -> "License"

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ $ seimei file --file /tmp/kimetsu.txt --parse @
 嘴平@伊之助
 ```
 
-# Licence
+# License
 [Mit](LICENSE)
 
 # Author


### PR DESCRIPTION
This PR corrects the spelling.

Use "License" instead of "Licence"